### PR TITLE
Pulled the API Token retrieval out of sample.html/js and into a separate, manual utilitity

### DIFF
--- a/examples/website-integration/sample.html
+++ b/examples/website-integration/sample.html
@@ -53,7 +53,7 @@
 		var perspectiveName = "Main Kiosk";
 		var venueId = 'mappedin-mall';
 		
-		// DEV/TESTING: Use the Token.html utility to retrieve your 48h API access token.
+		// DEV/TESTING: Use the token.html utility to retrieve your 48h API access token. Paste the results in here as the definition for token
 		// PROCUTION: Retrieve the access token dynamically from your server, which holds your API key and secret and does the OATH authentication itself
 		var token = {}
 

--- a/examples/website-integration/sample.html
+++ b/examples/website-integration/sample.html
@@ -52,19 +52,18 @@
 	<script>
 		var perspectiveName = "Main Kiosk";
 		var venueId = 'mappedin-mall';
-		// Authenticate with the API keys with the MappedIn server
-		var grant = { 
-			grant_type: "client_credentials", 
-			// You will need to request your own API client and secret keys by contacting support@mappedin.ca
-			client_id: "<your key>", 
-			client_secret: "<your secret>" 
-		};
-		authenticate(grant, function (result) {
-			// Initialize the Leaflet map and start loading the map tiles for our venue
-			init(venueId, perspectiveName, function () {
-				console.log("initialized");
-			});
+		
+		// DEV/TESTING: Use the Token.html utility to retrieve your 48h API access token.
+		// PROCUTION: Retrieve the access token dynamically from your server, which holds your API key and secret and does the OATH authentication itself
+		var token = {}
+
+		if (Object.keys(token).length == 0) {
+			document.write("EMTPY TOKEN! For testing you can use Token.html to calculate your temporary access token, and paste it into sample.html")
+		}
+		init(venueId, perspectiveName, function () {
+			console.log("initialized");
 		});
+
 	</script>
 
 </body>

--- a/examples/website-integration/sample.js
+++ b/examples/website-integration/sample.js
@@ -1,7 +1,5 @@
 /*global $*/
 // Setting up our global variables
-var token;
-
 
 // We will be using MappedIn API V1
 var host = {

--- a/examples/website-integration/token fetcher/token.html
+++ b/examples/website-integration/token fetcher/token.html
@@ -12,15 +12,16 @@
 </head>
 <body>
 	<h1>For test/development purposes only.</h1><br>
-	<p>Use this sample tool to retrieve your MappedIn API token, which needs to be sent with any query against the MappedIn API. It should be valid for two days (you can inspect the "expires_in" property of the token to be sure.</p>
+	<p>Use this sample tool to retrieve your MappedIn API token, which needs to be sent with any query against the MappedIn API. It should be valid for two days (you can inspect the "expires_in" property of the token to be sure.)</p>
 	<p>For production usage, you need to set up your own server your app can query for your current token. Your server should cache the current token, and only request a new one when the old token is close to expiry.</p>
 	<p><b>DO NOT STORE YOUR API KEY AND SECRET INSIDE YOUR WEBPAGE</b></p>
 	<br>
-	<p>Input your key and secret, then hit submit. Copy the result into the "token" definition of sample.js</p>
-	<form id="form">
-	  API Key: <input type="text" id="keyField" value=""><br>
-	  Secret: <input type="text" id="secretField" value=""><br><br>
-	  <input type="button" onclick="getToken(this.form)" value="Submit">
+	<p>Input your key and secret, then hit submit. Copy the resulant JSON into the "token" definition of sample.html</p>
+	<form id="form" style="table;padding: 5px">
+		<div style = "display: table-row"><label style="display: table-cell; padding: 5px" align = "right">API Key: </label><input type="text" style="display: table-cell; width: 300px" id="keyField" value=""></div>
+		<div style = "display: table-row"><label style="display: table-cell; padding: 5px" align = "right">Secret: </label><input type="text" style="display: table-cell; width: 300px" id="secretField" value=""></div>
+		<input type="button" onclick="getToken(this.form)" value="Submit">
+
 	</form>
 
 	</div>

--- a/examples/website-integration/token fetcher/token.html
+++ b/examples/website-integration/token fetcher/token.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head> 
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
+
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+</head>
+<body>
+	<h1>For test/development purposes only.</h1><br>
+	<p>Use this sample tool to retrieve your MappedIn API token, which needs to be sent with any query against the MappedIn API. It should be valid for two days (you can inspect the "expires_in" property of the token to be sure.</p>
+	<p>For production usage, you need to set up your own server your app can query for your current token. Your server should cache the current token, and only request a new one when the old token is close to expiry.</p>
+	<p><b>DO NOT STORE YOUR API KEY AND SECRET INSIDE YOUR WEBPAGE</b></p>
+	<br>
+	<p>Input your key and secret, then hit submit. Copy the result into the "token" definition of sample.js</p>
+	<form id="form">
+	  API Key: <input type="text" id="keyField" value=""><br>
+	  Secret: <input type="text" id="secretField" value=""><br><br>
+	  <input type="button" onclick="getToken(this.form)" value="Submit">
+	</form>
+
+	</div>
+	<script>
+		var host = {
+			auth: 'https://auth.mappedin.com',
+			api: 'https://api.mappedin.com/1/'
+		}
+
+		// Authenticate with the API keys with the MappedIn server
+		var grant = { 
+			grant_type: "client_credentials", 
+			// You will need to request your own API client and secret keys by contacting support@mappedin.ca
+		   	client_id: "<your key>", 
+			client_secret: "<your secret>" 
+		};
+
+		function getToken(form){
+			
+			grant.client_id = form.keyField.value;
+			grant.client_secret = form.secretField.value;
+			authenticate(grant, displayKey);
+		};
+
+		function displayKey(token) {
+			console.log(token);
+			document.write(JSON.stringify(token));
+		};
+
+		function authenticate(grant, cb) {
+			$.ajax({ 
+			url: host.auth + '/oauth2/token', 
+			data: grant, 
+			type: 'POST',
+			success: function (result) {
+				cb(result);
+			},
+			error: function (result) {
+				console.log("Error Authenticating.")
+			}});
+		};
+	</script>
+
+</body>
+</html>


### PR DESCRIPTION
The current setup encourages developers to put their key and secret into the webpage they send to the user, which is bad for security. This sample will now let the generate the token with the token.html utility, which they copy into sample.html every day, until they have a proper server set up to do it for them.