### PR TITLE
Imp 272 multifloordemo fix

### DIFF
--- a/examples/Demo/index.js
+++ b/examples/Demo/index.js
@@ -208,24 +208,19 @@ function onDataLoaded() {
 	var locationsWithNoEntrancesMap = {};
 	var locationsMap = {};
 	var locations = venue.locations;
-	for (var j = 0, jLen = locations.length; j < jLen; j++) {
+	for (var j = 0, jLen = locations.length; j < jLen; ++j) {
 		var location = locations[j];
 
 		if (location.polygons.length > 0) {
 			locationsMap[location.id] = location;
 		}
 			var locationPolygons = location.polygons;
-
-
 			for (var k = 0, kLen = locationPolygons.length; k < kLen; ++k) {
 				var polygon = locationPolygons[k];
-				
-				
 				//Find the locations which have atleast one polygon with no entrances
 				if (polygon.entrances.length === 0){
 					locationsWithNoEntrancesMap[location.id] = location;
 				}
-				
 				mapView.addInteractivePolygon(polygon.id)
 				// A polygon may be attached to more than one location. If that is the case for your venue,
 				// you will need some way of determinng which is the "primary" location when it's clicked on.
@@ -234,7 +229,6 @@ function onDataLoaded() {
 					locationsByPolygon[polygon.id] = location
 				}
 			}
-		
 	}
 	//Comparison between locationMap and locationWithNoEntrancesMap to delete the locations which 
 	//contain atleast one polygon with no entrances

--- a/examples/Demo/index.js
+++ b/examples/Demo/index.js
@@ -255,7 +255,7 @@ function onDataLoaded() {
 	mapsSortedByElevation = venue.maps.sort((a, b) => b.elevation - a.elevation);
 
 	// Shows off the pathing
-	drawRandomPath()
+	//drawRandomPath()
 
 	mapView.labelAllLocations({
 		excludeTypes: [] // If there are certain Location types you don't want to have labels (like amenities), exclude them here)

--- a/examples/Demo/index.js
+++ b/examples/Demo/index.js
@@ -145,7 +145,6 @@ function drawSingleFloorPath(directions, startPolygon, endPolygon) {
 
 // Draws a random path, highlighting the locations and focusing on the path and polygons
 function drawRandomPath() {
-	console.log(polygonedLocations);
 	var startLocation = getRandomInArray(polygonedLocations)
 	var startPolygon = getRandomInArray(startLocation.polygons)
 	var startNode = getRandomInArray(startPolygon.entrances);
@@ -153,8 +152,6 @@ function drawRandomPath() {
 	var endLocation = getRandomInArray(polygonedLocations)
 	var endPolygon = getRandomInArray(endLocation.polygons)
 	var endNode = getRandomInArray(endPolygon.entrances);
-
-
 
 	startNode.directionsTo(endNode, null, function(error, directions) {
 		if (error || directions.path.length == 0) {

--- a/examples/Demo/index.js
+++ b/examples/Demo/index.js
@@ -119,7 +119,7 @@ function drawMultiFloorPath(directions, startPolygon, endPolygon) {
 				}})
 			mapExpanded = true
 		})
-		.then(() => new Promise((resolve) => setTimeout(resolve, 100)))
+		.then(() => new Promise((resolve) => setTimeout(resolve, 9000)))
 		.then(() => {
 			drawRandomPath()
 		})
@@ -136,7 +136,7 @@ function drawSingleFloorPath(directions, startPolygon, endPolygon) {
 	mapView.focusOnPath(directions.path, [startPolygon, endPolygon], true, 2000)
 
 	mapView.drawPath(directions.path)
-	new Promise((resolve) => setTimeout(resolve, 100))
+	new Promise((resolve) => setTimeout(resolve, 9000))
 		.then(() => {
 			drawRandomPath()
 		})


### PR DESCRIPTION
Potential fix for the TypeError that occurs when calling the directionsTo function from the web sdk. When drawRandomPath() is called, it picks a random location, then a random polygon and then startNode and endNode are set to a random entrance of those polygons.  The error is happening because polygonedLocations contains some locations that have polygons with no entrances.  

This fix filters out the locations that have polygons with no entrances.