### PR TITLE
Fixing offline multi floor directions

### DIFF
--- a/examples/Demo/index.js
+++ b/examples/Demo/index.js
@@ -94,7 +94,7 @@ function getRandomInArray(array) {
 // Returns list of maps used in directions, sorted by elevation
 function getMapsInJourney(directions) {
 	var uniqueMapHash = {}
-	directions.directions.forEach((direction) => {
+	directions.instructions.forEach((direction) => {
 		uniqueMapHash[direction.node.map] = true
 	})
 	var mapIds = new Array();


### PR DESCRIPTION
It was referencing directions instead of instructions. Directions is used by online directions, but until https://github.com/MappedIn/mapview-js/pull/435/files is merged, it will not work for offline directions. Since we want to encourage people to use offline directions, we should make this change and fix the demo.